### PR TITLE
Add slash-create starters

### DIFF
--- a/examples/slash-create-typescript/README.md
+++ b/examples/slash-create-typescript/README.md
@@ -1,0 +1,14 @@
+---
+title: /create TypeScript server
+description: Create Discord slash commands from a slash-create TypeScript webserver.
+buttonSource: https://github.com/Snazzah/slash-create-template/tree/typescript
+tags:
+  - slash-create
+  - discord
+  - bot
+  - typescript
+---
+
+# /create TypeScript Template
+
+See the template README [here](https://github.com/Snazzah/slash-create-template/tree/typescript) for instructions.

--- a/examples/slash-create/README.md
+++ b/examples/slash-create/README.md
@@ -1,0 +1,14 @@
+---
+title: /create server
+description: Create Discord slash commands from a slash-create webserver.
+buttonSource: https://github.com/Snazzah/slash-create-template/tree/master
+tags:
+  - slash-create
+  - discord
+  - bot
+  - javascript
+---
+
+# /create Template
+
+See the template README [here](https://github.com/Snazzah/slash-create-template/tree/master) for instructions.


### PR DESCRIPTION
This adds starters for [slash-create](https://github.com/Snazzah/slash-create) using it's [JavaScript template](https://github.com/Snazzah/slash-create-template/tree/master) and [TypeScript template](https://github.com/Snazzah/slash-create-template/tree/typescript). Not sure how icons get selected for each one, but I can provide one if needed.