### PR TITLE
Remove import bodyParser in favor express body-parser middleware

### DIFF
--- a/examples/expressjs/package.json
+++ b/examples/expressjs/package.json
@@ -11,7 +11,6 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/examples/expressjs/src/index.ts
+++ b/examples/expressjs/src/index.ts
@@ -1,12 +1,11 @@
-import bodyParser from "body-parser";
 import express from "express";
 
 const app = express();
 const port = process.env.PORT || 3333;
 
-app.use(bodyParser.json());
-app.use(bodyParser.raw({ type: "application/vnd.custom-type" }));
-app.use(bodyParser.text({ type: "text/html" }));
+app.use(express.json());
+app.use(express.raw({ type: "application/vnd.custom-type" }));
+app.use(express.text({ type: "text/html" }));
 
 app.get("/", async (req, res) => {
   res.json({ Hello: "World" });

--- a/examples/expressjs/yarn.lock
+++ b/examples/expressjs/yarn.lock
@@ -141,7 +141,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
From Express 4.16+ you don't need to import body-parser anymore.