### PR TITLE
bump deno dockerfile version

### DIFF
--- a/examples/deno/Dockerfile
+++ b/examples/deno/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.16.2
+FROM denoland/deno:1.23.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps the deno docker image to most recent v1.23.0
